### PR TITLE
fix: Cleaning up fluid tanks

### DIFF
--- a/src/main/java/dev/galacticraft/machinelib/client/api/screen/MachineScreen.java
+++ b/src/main/java/dev/galacticraft/machinelib/client/api/screen/MachineScreen.java
@@ -858,11 +858,15 @@ public class MachineScreen<Machine extends MachineBlockEntity, Menu extends Mach
                     }
                     RenderSystem.setShaderTexture(0, sprite.atlasLocation());
                     RenderSystem.setShaderColor((fluidColor >> 16 & 0xFF) / 255.0F, (fluidColor >> 8 & 0xFF) / 255.0F, (fluidColor & 0xFF) / 255.0F, (fluidColor >> 24 & 0xFF) / 255.0F);
+
                     double v = (1.0 - ((double) tank.getAmount() / (double) tank.getCapacity()));
+                    int airHeight = (int) (v * tank.getHeight());
+                    int fluidHeight = tank.getHeight() - airHeight;
+
                     if (!fillFromTop) {
-                        DrawableUtil.drawTexturedQuad_F(matrices.last().pose(), this.leftPos, this.leftPos + tank.getWidth(), this.topPos + tank.getHeight(), (float) (this.topPos + (v * tank.getHeight())), tank.getWidth(), sprite.getU0(), sprite.getU1(), sprite.getV0(), (float) (sprite.getV0() + ((sprite.getV1() - sprite.getV0()) * v)));
+                        blit(matrices, this.leftPos + tank.getX(), this.topPos + tank.getY() + airHeight, 0, tank.getWidth(), fluidHeight, sprite);
                     } else {
-                        DrawableUtil.drawTexturedQuad_F(matrices.last().pose(), this.leftPos, this.leftPos + tank.getWidth(), this.topPos, (float) (this.topPos + ((1.0 - v) * tank.getHeight())), tank.getWidth(), sprite.getU0(), sprite.getU1(), sprite.getV0(), (float) (sprite.getV0() + ((sprite.getV1() - sprite.getV0()) * v)));
+                        blit(matrices, this.leftPos + tank.getX(), this.topPos + tank.getY(), 0, tank.getWidth(), fluidHeight, sprite);
                     }
                 }
 
@@ -985,7 +989,7 @@ public class MachineScreen<Machine extends MachineBlockEntity, Menu extends Mach
 
         RenderSystem.disableDepthTest();
         color |= (255 << 24);
-//        fillGradient(matrices, this.leftPos + x, this.topPos + y, this.leftPos + x + 16, this.topPos + y + 16, color, color);
+        fillGradient(matrices, this.leftPos + x, this.topPos + y, this.leftPos + x + 16, this.topPos + y + 16, color, color);
         RenderSystem.colorMask(true, true, true, true);
         RenderSystem.enableDepthTest();
     }

--- a/src/main/java/dev/galacticraft/machinelib/client/api/screen/MachineScreen.java
+++ b/src/main/java/dev/galacticraft/machinelib/client/api/screen/MachineScreen.java
@@ -874,7 +874,7 @@ public class MachineScreen<Machine extends MachineBlockEntity, Menu extends Mach
                     this.focusedTank = tank;
                     RenderSystem.disableDepthTest();
                     RenderSystem.colorMask(true, true, true, false);
-                    GuiComponent.fill(matrices, this.leftPos + tank.getX(), this.topPos + tank.getY(), this.leftPos + tank.getWidth(), this.topPos + tank.getHeight(), 0x80ffffff);
+                    GuiComponent.fill(matrices, this.leftPos + tank.getX(), this.topPos + tank.getY(), this.leftPos + tank.getX() + tank.getWidth(), this.topPos + tank.getY() + tank.getHeight(), 0x80ffffff);
                     RenderSystem.colorMask(true, true, true, true);
                     RenderSystem.enableDepthTest();
                 }

--- a/src/main/java/dev/galacticraft/machinelib/client/api/screen/MachineScreen.java
+++ b/src/main/java/dev/galacticraft/machinelib/client/api/screen/MachineScreen.java
@@ -857,7 +857,7 @@ public class MachineScreen<Machine extends MachineBlockEntity, Menu extends Mach
                         if (sprite == null) throw new IllegalStateException("Water sprite is null");
                     }
                     RenderSystem.setShaderTexture(0, sprite.atlasLocation());
-                    RenderSystem.setShaderColor(0xFF, fluidColor >> 16 & 0xFF, fluidColor >> 8 & 0xFF, fluidColor & 0xFF);
+                    RenderSystem.setShaderColor((fluidColor >> 16 & 0xFF) / 255.0F, (fluidColor >> 8 & 0xFF) / 255.0F, (fluidColor & 0xFF) / 255.0F, (fluidColor >> 24 & 0xFF) / 255.0F);
                     double v = (1.0 - ((double) tank.getAmount() / (double) tank.getCapacity()));
                     if (!fillFromTop) {
                         DrawableUtil.drawTexturedQuad_F(matrices.last().pose(), this.leftPos, this.leftPos + tank.getWidth(), this.topPos + tank.getHeight(), (float) (this.topPos + (v * tank.getHeight())), tank.getWidth(), sprite.getU0(), sprite.getU1(), sprite.getV0(), (float) (sprite.getV0() + ((sprite.getV1() - sprite.getV0()) * v)));
@@ -985,7 +985,7 @@ public class MachineScreen<Machine extends MachineBlockEntity, Menu extends Mach
 
         RenderSystem.disableDepthTest();
         color |= (255 << 24);
-        fillGradient(matrices, this.leftPos + x, this.topPos + y, this.leftPos + x + 16, this.topPos + y + 16, color, color);
+//        fillGradient(matrices, this.leftPos + x, this.topPos + y, this.leftPos + x + 16, this.topPos + y + 16, color, color);
         RenderSystem.colorMask(true, true, true, true);
         RenderSystem.enableDepthTest();
     }

--- a/src/test/java/dev/galacticraft/machinelib/testmod/block/TestModMachineTypes.java
+++ b/src/test/java/dev/galacticraft/machinelib/testmod/block/TestModMachineTypes.java
@@ -76,6 +76,7 @@ public class TestModMachineTypes {
                     )::build,
             MachineFluidStorage.builder().single(TestModSlotGroupTypes.WATER,
                     FluidResourceSlot.builder()
+                            .pos(96, 16)
                             .capacity(FluidConstants.BUCKET * 10)
                             ::build
             )::build


### PR DESCRIPTION
I have fixed the fluid tanks so that they now render properly. I first fixed the coordinates so that things are rendered in the right spot. And then I switched the sprite rendering to just call blit straight up and pass along the sprite so that blit can get the measurements it needs on its side. I also moved the tank in the example mode simple machine so that it is not crowding the top left corner. 