### PR TITLE
fix: Updating menu screen 

### DIFF
--- a/src/main/java/dev/galacticraft/machinelib/impl/menu/sync/MachineConfigurationSyncHandler.java
+++ b/src/main/java/dev/galacticraft/machinelib/impl/menu/sync/MachineConfigurationSyncHandler.java
@@ -87,9 +87,11 @@ public class MachineConfigurationSyncHandler implements MenuSyncHandler {
         }
         if ((ref & 0b0100) != 0) {
             this.status = MachineLib.MACHINE_STATUS_REGISTRY.get(buf.readResourceLocation());
+            this.configuration.setStatus(this.status);
         }
         if ((ref & 0b1000) != 0) {
             this.redstone = RedstoneActivation.VALUES[buf.readByte()];
+            this.configuration.setRedstoneActivation(this.redstone);
         }
     }
 }

--- a/src/test/java/dev/galacticraft/machinelib/testmod/item/BatteryItem.java
+++ b/src/test/java/dev/galacticraft/machinelib/testmod/item/BatteryItem.java
@@ -22,9 +22,15 @@
 
 package dev.galacticraft.machinelib.testmod.item;
 
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.Nullable;
 import team.reborn.energy.api.base.SimpleEnergyItem;
+
+import java.util.List;
 
 public class BatteryItem extends Item implements SimpleEnergyItem {
     private final long capacity;
@@ -32,6 +38,12 @@ public class BatteryItem extends Item implements SimpleEnergyItem {
     public BatteryItem(Properties properties, long capacity) {
         super(properties);
         this.capacity = capacity;
+    }
+
+    @Override
+    public void appendHoverText(ItemStack itemStack, @Nullable Level level, List<Component> lines, TooltipFlag tooltipFlag) {
+        lines.add(Component.literal("Energy: " + getStoredEnergy(itemStack) + " / " + getEnergyCapacity(itemStack)));
+        super.appendHoverText(itemStack, level, lines, tooltipFlag);
     }
 
     @Override

--- a/src/test/java/dev/galacticraft/machinelib/testmod/item/TestModItems.java
+++ b/src/test/java/dev/galacticraft/machinelib/testmod/item/TestModItems.java
@@ -30,6 +30,7 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import team.reborn.energy.api.EnergyStorage;
 import team.reborn.energy.api.base.InfiniteEnergyStorage;
 import team.reborn.energy.api.base.SimpleEnergyItem;
@@ -52,6 +53,10 @@ public class TestModItems {
         });
         ItemGroupEvents.modifyEntriesEvent(CreativeModeTabs.TOOLS_AND_UTILITIES).register(entries -> {
             entries.accept(INFINITE_BATTERY);
+            entries.accept(BASIC_BATTERY);
+            ItemStack chargedBattery = new ItemStack(BASIC_BATTERY);
+            BASIC_BATTERY.setStoredEnergy(chargedBattery, BASIC_BATTERY.getEnergyCapacity(chargedBattery));
+            entries.accept(chargedBattery);
         });
     }
 }


### PR DESCRIPTION
The menu screen does not properly update the status, ie if you put coal in the coal generator in GC the status is kept as whatever it was no matter what happens to the energy cycle. When reading the buffer in the sync handler on the client side we were only updating `status` in `MachineConfigurationSyncHandler` I have also added updates to `configuration` as well since that configuration is the same reference as in the `MachineMenu` which `MachineScreen` has access to. 