### PR TITLE
fix: changed rendering order of dark and light energy overlays to fix visual glitch

### DIFF
--- a/src/main/java/dev/galacticraft/machinelib/client/api/screen/MachineScreen.java
+++ b/src/main/java/dev/galacticraft/machinelib/client/api/screen/MachineScreen.java
@@ -754,10 +754,12 @@ public class MachineScreen<Machine extends MachineBlockEntity, Menu extends Mach
     protected void drawCapacitor(GuiGraphics graphics, int mouseX, int mouseY) {
         long capacity = this.menu.energyStorage.getCapacity();
         if (capacity > 0 && this.capacitorHeight != 0) {
-            graphics.blit(Constant.ScreenTexture.OVERLAY_BARS, this.leftPos + this.capacitorX, this.topPos + this.capacitorY, ENERGY_BACKGROUND_X, ENERGY_BACKGROUND_Y, OVERLAY_WIDTH, OVERLAY_HEIGHT, OVERLAY_TEX_WIDTH, OVERLAY_TEX_HEIGHT);
+            int x = this.leftPos + this.capacitorX;
+            int y = this.topPos + this.capacitorY;
             long amount = this.menu.energyStorage.getAmount();
             float scale = (float) ((double) amount / (double) capacity);
-            graphics.blit(Constant.ScreenTexture.OVERLAY_BARS, this.leftPos + this.capacitorX, (int) Math.floor(this.topPos + this.capacitorY + this.capacitorHeight - (this.capacitorHeight * scale)), ENERGY_X, ENERGY_Y, OVERLAY_WIDTH, (int) Math.floor(OVERLAY_HEIGHT * scale), OVERLAY_TEX_WIDTH, OVERLAY_TEX_HEIGHT);
+            graphics.blit(Constant.ScreenTexture.OVERLAY_BARS, x, y, ENERGY_X, ENERGY_Y, OVERLAY_WIDTH, OVERLAY_HEIGHT, OVERLAY_TEX_WIDTH, OVERLAY_TEX_HEIGHT);
+            graphics.blit(Constant.ScreenTexture.OVERLAY_BARS, x, y, ENERGY_BACKGROUND_X, ENERGY_BACKGROUND_Y, OVERLAY_WIDTH, (int) (OVERLAY_HEIGHT * (1 - scale)), OVERLAY_TEX_WIDTH, OVERLAY_TEX_HEIGHT);
 
             if (mouseIn(mouseX, mouseY, this.leftPos + this.capacitorX, this.topPos + this.capacitorY, 16, this.capacitorHeight)) {
                 List<Component> lines = new ArrayList<>();

--- a/src/main/java/dev/galacticraft/machinelib/client/api/util/GraphicsUtil.java
+++ b/src/main/java/dev/galacticraft/machinelib/client/api/util/GraphicsUtil.java
@@ -22,11 +22,23 @@
 
 package dev.galacticraft.machinelib.client.api.util;
 
+import org.joml.Matrix4f;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import com.mojang.blaze3d.vertex.BufferUploader;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.Tesselator;
+import com.mojang.blaze3d.vertex.VertexFormat;
+
 import net.fabricmc.fabric.api.transfer.v1.client.fluid.FluidVariantRendering;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariantAttributes;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.FastColor;
 import net.minecraft.world.level.material.Fluids;
 
@@ -49,15 +61,37 @@ public final class GraphicsUtil {
             assert sprite != null;
         }
 
+        int tileWidth = 16;
+        int tileHeight = 16;
         int fluidHeight = (int) (((double) available / (double) capacity) * height);
         int startY = fillFromTop ? y : y + (height - fluidHeight);
+        int depth = startY + fluidHeight;
+        float u0 = sprite.getU0();
+        float v0 = sprite.getV0();
 
-        for (int splitX = 0; splitX < width; splitX += Math.min(width, 16)) {
-            int realWidth = Math.min(width - splitX, 16);
-            for (int splitY = startY; splitY < startY + fluidHeight; splitY += realWidth) {
-                graphics.blit(x + splitX, splitY, 0, realWidth, Math.min(realWidth, startY + fluidHeight - splitY), sprite, r, g, b, 1.0f);
+        for (int splitX = 0; splitX < width; splitX += tileWidth) {
+            int realWidth = Math.min(width - splitX, tileWidth);
+            for (int splitY = startY; splitY < depth; splitY += tileHeight) {
+                int realHeight = Math.min(depth - splitY, tileHeight);
+                float u1 = sprite.getU((float) realWidth / (float) tileWidth);
+                float v1 = sprite.getV((float) realHeight / (float) tileHeight);
+                innerBlit(graphics.pose(), sprite.atlasLocation(), x + splitX, x + splitX + realWidth, splitY, splitY + realHeight, 0, u0, u1, v0, v1, r, g, b, 1.0f);
             }
         }
+    }
+
+    private static void innerBlit(PoseStack poseStack, ResourceLocation resourceLocation, int x0, int x1, int y0, int y1, int z, float u0, float u1, float v0, float v1, float r, float g, float b, float a) {
+        RenderSystem.setShaderTexture(0, resourceLocation);
+        RenderSystem.setShader(GameRenderer::getPositionTexColorShader);
+        RenderSystem.enableBlend();
+        Matrix4f matrix = poseStack.last().pose();
+        BufferBuilder bufferBuilder = Tesselator.getInstance().begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX_COLOR);
+        bufferBuilder.addVertex(matrix, (float)x0, (float)y0, (float)z).setUv(u0, v0).setColor(r, g, b, a);
+        bufferBuilder.addVertex(matrix, (float)x0, (float)y1, (float)z).setUv(u0, v1).setColor(r, g, b, a);
+        bufferBuilder.addVertex(matrix, (float)x1, (float)y1, (float)z).setUv(u1, v1).setColor(r, g, b, a);
+        bufferBuilder.addVertex(matrix, (float)x1, (float)y0, (float)z).setUv(u1, v0).setColor(r, g, b, a);
+        BufferUploader.drawWithShader(bufferBuilder.buildOrThrow());
+        RenderSystem.disableBlend();
     }
 
     public static void highlightElement(GuiGraphics graphics, int left, int top, int x, int y, int width, int height, int color) {


### PR DESCRIPTION
Changed rendering order of dark and light energy overlays so that the dark overlay is on top as this simplifies the calculations and fixes the visual problems.

This is a similar issue to [Galacticraft#393](https://github.com/TeamGalacticraft/Galacticraft/issues/393), but for the machine capacitors instead of oxygen tanks.