### PR TITLE
feat: allow hoppers, droppers and crafters to interact with Galacticraft machines

### DIFF
--- a/src/main/java/dev/galacticraft/machinelib/api/transfer/TransferType.java
+++ b/src/main/java/dev/galacticraft/machinelib/api/transfer/TransferType.java
@@ -28,7 +28,7 @@ public enum TransferType {
     INPUT(0x009001, true, false, true), // external: insertion only, players: insertion and extraction allowed
     OUTPUT(0xa7071e, false, true, false), // external: extraction only, players: extraction only
     STORAGE(0x008d90, true, true, true), // external: insertion and extraction allowed, players: insertion and extraction allowed
-    TRANSFER(0x908400, false, false, true); // external: immutable, players: insertion and extraction allowed - e.g. battery slots
+    TRANSFER(0x908400, true, true, true); // external: insertion and extraction allowed, players: insertion and extraction allowed - e.g. battery slots
 
     private final int color;
     private final boolean externalInsert;

--- a/src/main/java/dev/galacticraft/machinelib/api/transfer/TransferType.java
+++ b/src/main/java/dev/galacticraft/machinelib/api/transfer/TransferType.java
@@ -28,7 +28,8 @@ public enum TransferType {
     INPUT(0x009001, true, false, true), // external: insertion only, players: insertion and extraction allowed
     OUTPUT(0xa7071e, false, true, false), // external: extraction only, players: extraction only
     STORAGE(0x008d90, true, true, true), // external: insertion and extraction allowed, players: insertion and extraction allowed
-    TRANSFER(0x908400, true, true, true); // external: insertion and extraction allowed, players: insertion and extraction allowed - e.g. battery slots
+    TRANSFER(0x908400, false, false, true), // external: immutable, players: insertion and extraction allowed - e.g. battery slots
+    PROCESSING(0x908400, true, true, true); // external: insertion and extraction allowed, players: insertion and extraction allowed - e.g. bucket slots
 
     private final int color;
     private final boolean externalInsert;

--- a/src/main/java/dev/galacticraft/machinelib/client/api/screen/MachineScreen.java
+++ b/src/main/java/dev/galacticraft/machinelib/client/api/screen/MachineScreen.java
@@ -369,7 +369,7 @@ public class MachineScreen<Machine extends MachineBlockEntity, Menu extends Mach
      * @see #titleLabelY
      */
     protected void drawTitle(@NotNull GuiGraphics graphics) {
-        graphics.drawString(this.font, this.title, this.titleLabelX, this.titleLabelY, 0xFFFFFFFF, false);
+        graphics.drawString(this.font, this.title, this.titleLabelX, this.titleLabelY, 0xFF404040, false);
     }
 
     /**

--- a/src/main/java/dev/galacticraft/machinelib/impl/compat/transfer/ExposedSlotImpl.java
+++ b/src/main/java/dev/galacticraft/machinelib/impl/compat/transfer/ExposedSlotImpl.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Iterators;
 import dev.galacticraft.machinelib.api.compat.transfer.ExposedSlot;
 import dev.galacticraft.machinelib.api.storage.slot.ResourceSlot;
 import dev.galacticraft.machinelib.api.transfer.ResourceFlow;
+import dev.galacticraft.machinelib.api.transfer.TransferType;
 import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
 import net.fabricmc.fabric.api.transfer.v1.storage.TransferVariant;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
@@ -57,7 +58,14 @@ public abstract class ExposedSlotImpl<Resource, Variant extends TransferVariant<
 
     @Override
     public long extract(Variant variant, long maxAmount, TransactionContext transaction) {
-        return this.supportsExtraction() ? this.slot.extract(variant.getObject(), variant.getComponents(), maxAmount, transaction) : 0;
+        if (this.supportsExtraction()) {
+            if (this.slot.transferMode() == TransferType.TRANSFER) {
+                if (this.slot.getFilter().test(variant.getObject(), variant.getComponents()))
+                    return 0;
+            }
+            return this.slot.extract(variant.getObject(), variant.getComponents(), maxAmount, transaction);
+        }
+        return 0;
     }
 
     @Override

--- a/src/main/java/dev/galacticraft/machinelib/impl/compat/transfer/ExposedSlotImpl.java
+++ b/src/main/java/dev/galacticraft/machinelib/impl/compat/transfer/ExposedSlotImpl.java
@@ -59,9 +59,10 @@ public abstract class ExposedSlotImpl<Resource, Variant extends TransferVariant<
     @Override
     public long extract(Variant variant, long maxAmount, TransactionContext transaction) {
         if (this.supportsExtraction()) {
-            if (this.slot.transferMode() == TransferType.TRANSFER) {
-                if (this.slot.getFilter().test(variant.getObject(), variant.getComponents()))
+            if (this.slot.transferMode() == TransferType.PROCESSING) {
+                if (this.slot.getFilter().test(variant.getObject(), variant.getComponents())) {
                     return 0;
+                }
             }
             return this.slot.extract(variant.getObject(), variant.getComponents(), maxAmount, transaction);
         }

--- a/src/main/java/dev/galacticraft/machinelib/impl/storage/MachineItemStorageImpl.java
+++ b/src/main/java/dev/galacticraft/machinelib/impl/storage/MachineItemStorageImpl.java
@@ -91,12 +91,12 @@ public class MachineItemStorageImpl extends ResourceStorageImpl<Item, ItemResour
 
     @Override
     public boolean canPlaceItem(int i, ItemStack itemStack) {
-        return false;
+        return true;
     }
 
     @Override
     public boolean canTakeItem(Container container, int i, ItemStack itemStack) {
-        return false;
+        return true;
     }
 
     @Override

--- a/src/main/java/dev/galacticraft/machinelib/impl/storage/MachineItemStorageImpl.java
+++ b/src/main/java/dev/galacticraft/machinelib/impl/storage/MachineItemStorageImpl.java
@@ -91,12 +91,12 @@ public class MachineItemStorageImpl extends ResourceStorageImpl<Item, ItemResour
 
     @Override
     public boolean canPlaceItem(int i, ItemStack itemStack) {
-        return true;
+        return false;
     }
 
     @Override
     public boolean canTakeItem(Container container, int i, ItemStack itemStack) {
-        return true;
+        return false;
     }
 
     @Override

--- a/src/testmod/java/dev/galacticraft/machinelib/testmod/block/entity/GeneratorBlockEntity.java
+++ b/src/testmod/java/dev/galacticraft/machinelib/testmod/block/entity/GeneratorBlockEntity.java
@@ -54,7 +54,7 @@ public class GeneratorBlockEntity extends MachineBlockEntity {
 
     public static final StorageSpec STORAGE_SPEC = StorageSpec.of(
             MachineItemStorage.spec(
-                    ItemResourceSlot.builder(TransferType.TRANSFER)
+                    ItemResourceSlot.builder(TransferType.PROCESSING)
                             .pos(8, 62)
                             .filter(ResourceFilters.CAN_INSERT_ENERGY)
                             .capacity(32),

--- a/src/testmod/java/dev/galacticraft/machinelib/testmod/block/entity/MelterBlockEntity.java
+++ b/src/testmod/java/dev/galacticraft/machinelib/testmod/block/entity/MelterBlockEntity.java
@@ -68,7 +68,7 @@ public class MelterBlockEntity extends MachineBlockEntity {
                     ItemResourceSlot.builder(TransferType.INPUT)
                             .pos(59, 42)
                             .filter(ResourceFilters.ofResource(Items.COBBLESTONE)),
-                    ItemResourceSlot.builder(TransferType.TRANSFER)
+                    ItemResourceSlot.builder(TransferType.PROCESSING)
                             .pos(152, 62)
                             .filter(ResourceFilters.canInsertFluid(Fluids.LAVA))
             ),

--- a/src/testmod/java/dev/galacticraft/machinelib/testmod/block/entity/MixerBlockEntity.java
+++ b/src/testmod/java/dev/galacticraft/machinelib/testmod/block/entity/MixerBlockEntity.java
@@ -66,10 +66,10 @@ public class MixerBlockEntity extends MachineBlockEntity {
                             .pos(8, 8)
                             .filter(ResourceFilters.CAN_EXTRACT_ENERGY)
                             .capacity(32),
-                    ItemResourceSlot.builder(TransferType.TRANSFER)
+                    ItemResourceSlot.builder(TransferType.PROCESSING)
                             .pos(48, 8)
                             .filter(ResourceFilters.canExtractFluid(Fluids.WATER)),
-                    ItemResourceSlot.builder(TransferType.TRANSFER)
+                    ItemResourceSlot.builder(TransferType.PROCESSING)
                             .pos(70, 8)
                             .filter(ResourceFilters.canExtractFluid(Fluids.LAVA)),
                     ItemResourceSlot.builder(TransferType.OUTPUT)


### PR DESCRIPTION
- Hoppers, droppers and crafters can be used to insert items into TransferType.INPUT, TransferType.STORAGE and TransferType.PROCESSING slots of machines provided they match the filter.

- Hoppers can be used to remove items from TransferType.OUTPUT and TransferType.STORAGE slots.

- Hoppers can be used to remove items from TransferType.PROCESSING slots provided that they **NO LONGER** match the filter.

Note that the corresponding side of the machine needs to be configured to allow items in/out/both.

<del>This does not work with dispensers quite yet for some reason.</del> _Dispensers do not insert items into vanilla containers either._

Simple examples include automatically supplying a coal generator with coal or creating an automatic smelter using an electric furnace etc.

Examples of the behavior of TransferType.PROCESSING slots include inserting empty oxygen tanks into the oxygen compressor and only when they are full do they no longer match the canInsertFluid filter and may be removed using a hopper. Other examples include filling/emptying buckets or charging/discharging batteries and removing them with a hopper when the buckets/batteries are full/empty.