### PR TITLE
feature: refined storage compatibility

### DIFF
--- a/src/main/java/dev/galacticraft/machinelib/api/block/MachineBlock.java
+++ b/src/main/java/dev/galacticraft/machinelib/api/block/MachineBlock.java
@@ -272,16 +272,14 @@ public abstract class MachineBlock extends BaseBlock {
     public @NotNull ItemStack getCloneItemStack(LevelReader reader, BlockPos pos, BlockState state) {
         ItemStack stack = super.getCloneItemStack(reader, pos, state);
 
-        if (Screen.hasAltDown()) {
-            // todo: add a separate item to copy/paste config data that also works in survival instead of this
-            BlockEntity blockEntity = reader.getBlockEntity(pos);
-            if (blockEntity instanceof MachineBlockEntity machine) {
-                CompoundTag config = new CompoundTag();
-                config.put(Constant.Nbt.CONFIGURATION, machine.getIOConfig().createTag());
-                config.put(Constant.Nbt.SECURITY, machine.getSecurity().createTag());
-                config.put(Constant.Nbt.REDSTONE_MODE, machine.getRedstoneMode().createTag());
-                BlockItem.setBlockEntityData(stack, blockEntity.getType(), config);
-            }
+        // todo: add a separate item to copy/paste config data that also works in survival instead of this
+        BlockEntity blockEntity = reader.getBlockEntity(pos);
+        if (blockEntity instanceof MachineBlockEntity machine) {
+            CompoundTag config = new CompoundTag();
+            config.put(Constant.Nbt.CONFIGURATION, machine.getIOConfig().createTag());
+            config.put(Constant.Nbt.SECURITY, machine.getSecurity().createTag());
+            config.put(Constant.Nbt.REDSTONE_MODE, machine.getRedstoneMode().createTag());
+            BlockItem.setBlockEntityData(stack, blockEntity.getType(), config);
         }
 
         return stack;

--- a/src/main/java/dev/galacticraft/machinelib/api/compat/transfer/MachineInsertHandler.java
+++ b/src/main/java/dev/galacticraft/machinelib/api/compat/transfer/MachineInsertHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021-2026 Team Galacticraft
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.galacticraft.machinelib.api.compat.transfer;
+
+import dev.galacticraft.machinelib.api.storage.ResourceStorage;
+import dev.galacticraft.machinelib.api.storage.slot.ResourceSlot;
+import net.fabricmc.fabric.api.transfer.v1.storage.TransferVariant;
+import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
+
+@FunctionalInterface
+public interface MachineInsertHandler<Resource, Slot extends ResourceSlot<Resource>> {
+    /**
+     * Allows for a custom implementation of the {@code insert} method.
+     *
+     * @param storage the storage to insert into
+     * @param variant the variant to move
+     * @param maxAmount the maximum amount of resources to move
+     * @param transaction the transaction context to use
+     * @return the amount of resources moved
+     */
+    long insert(ResourceStorage<Resource, Slot> storage, TransferVariant<Resource> variant, long maxAmount, TransactionContext transaction);
+}

--- a/src/main/java/dev/galacticraft/machinelib/api/storage/ResourceStorage.java
+++ b/src/main/java/dev/galacticraft/machinelib/api/storage/ResourceStorage.java
@@ -30,6 +30,7 @@ import dev.galacticraft.machinelib.api.misc.Serializable;
 import dev.galacticraft.machinelib.api.storage.slot.ResourceSlot;
 import dev.galacticraft.machinelib.api.transfer.ResourceFlow;
 import net.fabricmc.fabric.api.transfer.v1.storage.TransferVariant;
+import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -52,6 +53,17 @@ public interface ResourceStorage<Resource, Slot extends ResourceSlot<Resource>> 
     void setParent(BlockEntity parent);
 
     boolean isValid();
+
+    /**
+     * Invokes the {@link dev.galacticraft.machinelib.api.compat.transfer.MachineInsertHandler#insert},
+     * if the parent block entity implements {@link dev.galacticraft.machinelib.api.compat.transfer.MachineInsertHandler}.
+     *
+     * @param variant the variant to move
+     * @param maxAmount the maximum amount of resources to move
+     * @param transaction the transaction context to use
+     * @return the amount of resources moved
+     */
+    long insert(TransferVariant<Resource> variant, long maxAmount, TransactionContext transaction);
 
     /**
      * Create an exposed storage for this storage.

--- a/src/main/java/dev/galacticraft/machinelib/impl/compat/transfer/ExposedStorageImpl.java
+++ b/src/main/java/dev/galacticraft/machinelib/impl/compat/transfer/ExposedStorageImpl.java
@@ -67,23 +67,23 @@ public class ExposedStorageImpl<Resource, Variant extends TransferVariant<Resour
     @Override
     public long insert(Variant variant, long maxAmount, TransactionContext transaction) {
         if (!this.storage.isValid()) return 0;
-        long requested = maxAmount;
+        long amount = this.storage.insert(variant, maxAmount, transaction);
         for (ExposedSlot<Resource, Variant> slot : this.slots) {
-            if (maxAmount == 0) return requested;
-            maxAmount -= slot.insert(variant, maxAmount, transaction);
+            if (amount == maxAmount) break;
+            amount += slot.insert(variant, maxAmount, transaction);
         }
-        return requested - maxAmount;
+        return amount;
     }
 
     @Override
     public long extract(Variant variant, long maxAmount, TransactionContext transaction) {
         if (!this.storage.isValid()) return 0;
-        long requested = maxAmount;
+        long amount = 0;
         for (ExposedSlot<Resource, Variant> slot : this.slots) {
-            if (maxAmount == 0) return requested;
-            maxAmount -= slot.extract(variant, maxAmount, transaction);
+            if (amount == maxAmount) return amount;
+            amount += slot.extract(variant, maxAmount, transaction);
         }
-        return requested - maxAmount;
+        return amount;
     }
 
     @Override

--- a/src/main/java/dev/galacticraft/machinelib/impl/storage/ResourceStorageImpl.java
+++ b/src/main/java/dev/galacticraft/machinelib/impl/storage/ResourceStorageImpl.java
@@ -23,9 +23,11 @@
 package dev.galacticraft.machinelib.impl.storage;
 
 import dev.galacticraft.machinelib.api.storage.ResourceStorage;
+import dev.galacticraft.machinelib.api.compat.transfer.MachineInsertHandler;
 import dev.galacticraft.machinelib.api.storage.slot.ResourceSlot;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongList;
+import net.fabricmc.fabric.api.transfer.v1.storage.TransferVariant;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.network.RegistryFriendlyByteBuf;
@@ -53,6 +55,14 @@ public abstract class ResourceStorageImpl<Resource, Slot extends ResourceSlot<Re
     @Override
     public boolean isValid() {
         return this.parent == null || !this.parent.isRemoved();
+    }
+
+    @Override
+    public long insert(TransferVariant<Resource> variant, long maxAmount, TransactionContext transaction) {
+        if (this.parent instanceof MachineInsertHandler handler) {
+            return handler.insert(this, variant, maxAmount, transaction);
+        }
+        return 0;
     }
 
     @Override


### PR DESCRIPTION
The purpose of this PR is to provide a way to register a custom implementation of the `insert` method for certain machines such as the Circuit Fabricator and (Electric) Compressor in order to support autocrafting with the Refined Storage mod (and to a certain extent, using pipes and hoppers).

The issue for the Circuit Fabricator is that the silicon gets put in the same slot, but a `MachineInsertHandler` can be used to split silicon between both slots.

The issue for the (Electric) Compressor is similar, however it will need to determine which recipe the ingredients match (hopefully uniquely) and then rearrange them into the correct arrangement in the grid.

Also fixes a crash on dedicated servers when trying to autocraft using Galacticraft machines.